### PR TITLE
Fix short-dated/low-variance mispricing in the characteristic-function pricers

### DIFF
--- a/stochastic-rs-quant/src/pricing.rs
+++ b/stochastic-rs-quant/src/pricing.rs
@@ -14,6 +14,7 @@ pub mod bjerksund_stensland;
 pub mod breeden_litzenberger;
 pub mod bsm;
 pub mod cgmysv;
+pub(crate) mod cf_quadrature;
 pub mod chooser;
 pub mod cliquet;
 pub mod compound;

--- a/stochastic-rs-quant/src/pricing/cf_quadrature.rs
+++ b/stochastic-rs-quant/src/pricing/cf_quadrature.rs
@@ -1,0 +1,57 @@
+//! Convergence-controlled quadrature for characteristic-function inversion.
+//!
+//! The Heston, Gil-Pelaez, Lewis and Carr-Madan pricers all invert a
+//! characteristic function by integrating an oscillatory-but-decaying integrand
+//! over `[a, ∞)`. The integrand's envelope only becomes negligible once `φ` is
+//! past its decay length, which grows like `1/√(v·τ)` as the maturity `τ` or
+//! the variance `v` shrink. A hardcoded finite upper limit therefore truncates
+//! a non-negligible tail for short-dated or low-variance options, which
+//! under-prices them by 15-35% and can even return arbitrage-violating negative
+//! call prices.
+//!
+//! [`integrate_to_convergence`] replaces the fixed bound: it accumulates
+//! tanh-sinh panels of geometrically growing width and stops once the tail
+//! contribution is negligible, so the effective upper limit adapts to the
+//! actual decay length for any `(τ, v, moneyness)`.
+
+use quadrature::double_exponential;
+
+/// Integrate `f` over `[a, ∞)` to a relative tolerance `tol`.
+///
+/// Successive tanh-sinh panels of geometrically growing width are summed until
+/// two consecutive panels each add less than `tol` relative to the running
+/// integral. `tol` is also the per-panel tanh-sinh target. Requiring two
+/// negligible panels (not one) guards against a panel that integrates to near
+/// zero by oscillatory cancellation while the envelope is still significant.
+pub(crate) fn integrate_to_convergence<F>(f: F, a: f64, tol: f64) -> f64
+where
+  F: Fn(f64) -> f64,
+{
+  const INITIAL_WIDTH: f64 = 50.0;
+  const GROWTH: f64 = 2.0;
+  const MAX_PANELS: usize = 40;
+
+  let mut lo = a;
+  let mut width = INITIAL_WIDTH;
+  let mut total = 0.0_f64;
+  let mut negligible_streak = 0u32;
+
+  for _ in 0..MAX_PANELS {
+    let panel = double_exponential::integrate(&f, lo, lo + width, tol).integral;
+    total += panel;
+
+    if panel.abs() <= tol * total.abs().max(1.0) {
+      negligible_streak += 1;
+      if negligible_streak >= 2 {
+        break;
+      }
+    } else {
+      negligible_streak = 0;
+    }
+
+    lo += width;
+    width *= GROWTH;
+  }
+
+  total
+}

--- a/stochastic-rs-quant/src/pricing/fourier/mod.rs
+++ b/stochastic-rs-quant/src/pricing/fourier/mod.rs
@@ -99,6 +99,39 @@ mod tests {
   const TOL_FOURIER: f64 = 0.15;
   const TOL_TIGHT: f64 = 0.05;
 
+  /// Gil-Pelaez and Lewis both integrated to a fixed `φ_max = 100`, which
+  /// truncates the slowly-decaying tail of the short-dated Heston integrand.
+  /// Pre-fix at τ=0.005/ATM the price was 0.488 vs a converged 0.577, and at
+  /// τ=0.01/K=105 it was 0.0100 vs 0.0030 (over 3× too large). Both must now
+  /// match the converged inversion and agree with each other.
+  #[test]
+  fn fourier_pricers_match_converged_short_dated() {
+    let model = HestonFourier {
+      v0: 0.04,
+      kappa: 1.5,
+      theta: 0.04,
+      sigma: 0.30,
+      rho: -0.7,
+      r: 0.05,
+      q: 0.0,
+    };
+    // (K, τ, converged call)
+    let cases = [(100.0, 0.005, 0.576581), (105.0, 0.01, 0.002966), (95.0, 0.01, 5.052617)];
+    for (k, t, expected) in cases {
+      let gp = GilPelaezPricer::price_call(&model, 100.0, k, 0.05, 0.0, t);
+      let lw = LewisPricer::price_call(&model, 100.0, k, 0.05, 0.0, t);
+      assert!(
+        (gp - expected).abs() < 1e-3,
+        "Gil-Pelaez at K={k}, τ={t}: got {gp}, converged {expected}"
+      );
+      assert!(
+        (lw - expected).abs() < 1e-3,
+        "Lewis at K={k}, τ={t}: got {lw}, converged {expected}"
+      );
+      assert!((gp - lw).abs() < 1e-3, "Gil-Pelaez {gp} and Lewis {lw} must agree");
+    }
+  }
+
   #[test]
   fn carr_madan_bsm_reference() {
     let model = BSMFourier {

--- a/stochastic-rs-quant/src/pricing/fourier/pricer.rs
+++ b/stochastic-rs-quant/src/pricing/fourier/pricer.rs
@@ -7,9 +7,9 @@ use ndarray::Array1;
 use ndrustfft::FftHandler;
 use ndrustfft::ndfft;
 use num_complex::Complex64;
-use quadrature::double_exponential;
 
 use super::FourierModelExt;
+use crate::pricing::cf_quadrature::integrate_to_convergence;
 
 /// Carr–Madan FFT pricer.
 ///
@@ -261,10 +261,8 @@ impl GilPelaezPricer {
       (kernel * phi).re
     };
 
-    let p1 =
-      0.5 + FRAC_1_PI * double_exponential::integrate(integrand_p1, 1e-8, 100.0, 1e-8).integral;
-    let p2 =
-      0.5 + FRAC_1_PI * double_exponential::integrate(integrand_p2, 1e-8, 100.0, 1e-8).integral;
+    let p1 = 0.5 + FRAC_1_PI * integrate_to_convergence(integrand_p1, 1e-8, 1e-8);
+    let p2 = 0.5 + FRAC_1_PI * integrate_to_convergence(integrand_p2, 1e-8, 1e-8);
 
     let call = s * (-q * t).exp() * p1 - k * (-r * t).exp() * p2;
     call.max(0.0)
@@ -295,7 +293,7 @@ impl LewisPricer {
       (kernel * phi).re
     };
 
-    let integral = double_exponential::integrate(integrand, 1e-8, 100.0, 1e-8).integral;
+    let integral = integrate_to_convergence(integrand, 1e-8, 1e-8);
 
     let call = s * disc * fwd_factor - sqrt_sk * disc * FRAC_1_PI * integral;
     call.max(0.0)

--- a/stochastic-rs-quant/src/pricing/heston.rs
+++ b/stochastic-rs-quant/src/pricing/heston.rs
@@ -9,8 +9,8 @@ use std::f64::consts::FRAC_1_PI;
 use implied_vol::DefaultSpecialFn;
 use implied_vol::ImpliedBlackVolatility;
 use num_complex::Complex64;
-use quadrature::double_exponential;
 
+use super::cf_quadrature::integrate_to_convergence;
 use crate::OptionType;
 use crate::traits::PricerExt;
 use crate::traits::TimeExt;
@@ -279,13 +279,74 @@ impl HestonPricer {
   /// - Heston, S. L. (1993)
   ///   https://doi.org/10.1093/rfs/6.2.327
   pub(self) fn p(&self, j: u8, tau: f64) -> f64 {
-    0.5 + FRAC_1_PI * double_exponential::integrate(self.re(j, tau), 0.00001, 50.0, 10e-6).integral
+    0.5 + FRAC_1_PI * integrate_to_convergence(self.re(j, tau), 0.00001, 1e-8)
   }
 }
 
 #[cfg(test)]
 mod tests {
   use super::*;
+
+  fn price(v0: f64, k: f64, sigma: f64, tau: f64) -> f64 {
+    // Long-run variance θ = v0 for these references.
+    HestonPricer::new(
+      100.0,
+      v0,
+      k,
+      0.05,
+      Some(0.0),
+      -0.7,
+      1.5,
+      v0,
+      sigma,
+      Some(0.0),
+      Some(tau),
+      None,
+      None,
+    )
+    .calculate_call_put()
+    .0
+  }
+
+  /// Short-dated / low-variance options must match the converged Fourier
+  /// integral. The former fixed `φ_max = 50` truncated a tail that only
+  /// decays past `φ ~ 1/√(vτ)`, under-pricing these by 15-35%. Converged
+  /// references are from a `scipy.integrate.quad` inversion to `∞`, validated
+  /// against the repo's own long-dated `HESTON_REF`. The τ=1 case pins that
+  /// the already-accurate long-dated regime is unchanged.
+  #[test]
+  fn short_dated_matches_converged_reference() {
+    // (v0, K, σ, τ, converged call)
+    let cases = [
+      (0.04, 100.0, 0.30, 0.02, 1.177515),
+      (0.01, 100.0, 0.20, 0.03, 0.768268),
+      (0.04, 100.0, 0.30, 1.00, 10.361856),
+    ];
+    for (v0, k, sigma, tau, expected) in cases {
+      let c = price(v0, k, sigma, tau);
+      assert!(
+        (c - expected).abs() < 2e-3,
+        "Heston call at v0={v0}, K={k}, σ={sigma}, τ={tau}: got {c}, converged {expected}"
+      );
+    }
+  }
+
+  /// Deep-OTM short-dated calls must be non-negative and ~0, not the negative
+  /// (arbitrage-violating) or spuriously-positive values the fixed integration
+  /// bound produced. Pre-fix: τ=0.1/K=150 → −0.0347, τ=0.01/K=110 → +0.062.
+  /// This exercises `HestonPricer` directly (no `.max(0.0)` clamp), so it pins
+  /// the integral itself, not a downstream floor — the root cause behind the
+  /// negative model prices in calibration issue #14.
+  #[test]
+  fn deep_otm_short_dated_non_negative() {
+    for (v0, k, sigma, tau) in [(0.04, 150.0, 0.50, 0.10), (0.04, 110.0, 0.30, 0.01)] {
+      let c = price(v0, k, sigma, tau);
+      assert!(
+        c > -1e-3 && c < 1e-2,
+        "deep-OTM call at K={k}, τ={tau} must be non-negative and ~0, got {c}"
+      );
+    }
+  }
 
   #[test]
   fn heston_single_price() {

--- a/stochastic-rs-quant/src/pricing/heston_stoch_corr/pricer.rs
+++ b/stochastic-rs-quant/src/pricing/heston_stoch_corr/pricer.rs
@@ -4,9 +4,9 @@
 use std::f64::consts::FRAC_1_PI;
 
 use num_complex::Complex64;
-use quadrature::double_exponential;
 
 use super::model::HestonStochCorrPricer;
+use crate::pricing::cf_quadrature::integrate_to_convergence;
 use crate::traits::TimeExt;
 
 impl HestonStochCorrPricer {
@@ -34,7 +34,7 @@ impl HestonStochCorrPricer {
       val.re
     };
 
-    let integral = double_exponential::integrate(integrand, 0.0, 200.0, 1e-8).integral;
+    let integral = integrate_to_convergence(integrand, 0.0, 1e-8);
     let call = (-alpha * log_k).exp() * FRAC_1_PI * integral;
     call.max(0.0)
   }

--- a/stochastic-rs-quant/src/pricing/heston_stoch_corr/tests.rs
+++ b/stochastic-rs-quant/src/pricing/heston_stoch_corr/tests.rs
@@ -21,6 +21,33 @@ fn paper_pricer() -> HestonStochCorrPricer {
   )
 }
 
+/// With the correlation process frozen (σ_ρ → 0, ρ pinned to a constant) the
+/// stochastic-correlation model collapses to standard Heston, so at ATM the
+/// two must price the same. The Carr-Madan inversion used a fixed `φ_max = 200`
+/// that truncated the short-dated tail: pre-fix at τ=0.02/ATM the two pricers
+/// disagreed by ~18%. Both are now integrated to convergence and agree to
+/// well under 1% down to τ=0.002.
+#[test]
+fn carr_madan_reduces_to_heston_short_dated() {
+  use crate::pricing::heston::HestonPricer;
+  let (rho, kappa, theta, sigma, v0, s, r) = (-0.7, 2.0, 0.04, 0.3, 0.04, 100.0, 0.03);
+  for tau in [0.02, 0.005, 0.002] {
+    let heston = HestonPricer::new(
+      s, v0, s, r, None, rho, kappa, theta, sigma, Some(0.0), Some(tau), None, None,
+    );
+    let heston_call = heston.calculate_call_put().0;
+    let hscm = HestonStochCorrPricer::new(
+      s, r, s, v0, kappa, theta, sigma, rho, 10.0, rho, 1e-10, 0.0, tau,
+    );
+    let hscm_call = hscm.price_call_carr_madan();
+    let reldiff = (heston_call - hscm_call).abs() / heston_call;
+    assert!(
+      reldiff < 0.01,
+      "HSCM(σ_ρ→0) must match Heston at τ={tau}: Heston={heston_call:.6}, HSCM={hscm_call:.6}, reldiff={reldiff:.4}"
+    );
+  }
+}
+
 #[test]
 fn char_func_at_zero_is_one() {
   let pricer = paper_pricer();


### PR DESCRIPTION
The Heston, Gil-Pelaez, Lewis and Carr-Madan (stochastic-correlation) pricers each invert a characteristic function over `[a, ∞)` with a hardcoded finite upper limit in the frequency variable — `50` in `heston.rs`, `100` in `fourier/pricer.rs`, `200` in `heston_stoch_corr/pricer.rs`. The integrand's envelope only decays once `φ` is past `~ 1/√(v·τ)`, so as the maturity `τ` or the variance shrink the fixed bound cuts off a non-negligible tail. For short-dated or low-variance options this under-prices by 15-35% and can return negative, arbitrage-violating call prices.

Reproductions on `main` (converged reference from a `quad`-to-∞ inversion, itself checked against the repo's `HESTON_REF`):

```
HestonPricer, S=K=100, r=0.05, v0=θ=0.04, σ=0.3, ρ=-0.7, κ=1.5
  τ=0.02                     call =  0.9988   converged 1.1775   (-15%)
  τ=0.03, v0=θ=0.01, σ=0.2   call =  0.4999   converged 0.7683   (-35%)
  τ=0.1, K=150, σ=0.5        call = -0.0347   (negative price)
  τ=1                        call = 10.3618   converged 10.3619  (correct)
```

The characteristic functions are fine — the τ=1 reference matches to ~1e-5, which isolates the error to truncation.

Those negative prices are the root cause behind the calibration in #14. `compute_model_prices_for_numeric` prices each quote through `HestonPricer` and then floors with `.max(0.0)`, so the deep-OTM one-month quotes in that report produce negative model prices that the clamp hides while the residual stays wrong.

Fix: replace the fixed upper limit with `integrate_to_convergence` (new `pricing/cf_quadrature.rs`), which sums tanh-sinh panels of geometrically growing width and stops once the tail is negligible relative to the running integral, so the effective upper limit adapts to the actual decay length for any `(τ, v, moneyness)`. All four pricers use the one helper. Long-dated prices are unchanged — the first panel already converges there — and the whole `τ ∈ [0.005, 2]` × vol × moneyness grid now matches the converged inversion to <1e-6 and stays non-negative.

The `.max(0.0)` clamps stay: with a converged integral they only floor the ~1e-8 quadrature residual on true-zero deep-OTM prices.

Tests (each fails before, passes after):
- `heston`: short-dated / low-vol prices vs the converged reference, and deep-OTM non-negativity checked on `HestonPricer` directly (no clamp), so it pins the integral rather than the floor.
- `fourier`: Gil-Pelaez and Lewis match the converged inversion and each other at short τ.
- `heston_stoch_corr`: with the correlation frozen (σ_ρ→0) the model reduces to Heston; the two now agree at short τ (18% apart before).

Left for a follow-up: the calibration loss integrals (`GL_U_MAX`, a fixed 64-node Gauss-Legendre rule in `cui_impl.rs` / `svj` / `double_heston` / `levy`) share the same fixed-bound cause, but they also integrate the gradient and the fixed node count under-resolves the short-τ oscillation, so they need node scaling too — kept out to keep this change focused.
